### PR TITLE
update plantuml, alpine and tomcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY_PATH=gmitirol
-FROM $REGISTRY_PATH/alpine310:v1
+FROM $REGISTRY_PATH/alpine311:v1
 LABEL maintainer="gmi-edv@i-med.ac.at"
 
 ARG PLANTUML_VERSION="v1.2020.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM $REGISTRY_PATH/alpine311:v1
 LABEL maintainer="gmi-edv@i-med.ac.at"
 
 ARG PLANTUML_VERSION="v1.2020.1"
-ARG TOMCAT_VERSION="9.0.31"
+ARG TOMCAT_VERSION="9.0.34"
 
 RUN set -xe && \
     BUILDDIR='/root/build' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG REGISTRY_PATH=gmitirol
 FROM $REGISTRY_PATH/alpine311:v1
 LABEL maintainer="gmi-edv@i-med.ac.at"
 
-ARG PLANTUML_VERSION="v1.2020.1"
+ARG PLANTUML_VERSION="v1.2020.7"
 ARG TOMCAT_VERSION="9.0.34"
 
 RUN set -xe && \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Docker image for PlantUML server
 ================================
 
-Provides a minimal PlantUML server docker image based on our [Alpine Linux 3.10 base image](https://github.com/gmitirol/alpine310/) and the [PlantUML server](https://github.com/plantuml/plantuml-server) project.
+Provides a minimal PlantUML server docker image based on our [Alpine Linux 3.11 base image](https://github.com/gmitirol/alpine310/) and the [PlantUML server](https://github.com/plantuml/plantuml-server) project.
 The default PlantUML tomcat port `8080` is exposed for HTTP by default, but can be configured via docker compose/swarm service definitions.


### PR DESCRIPTION
This MR updates:
- plantuml to v1.2020.7 (was: v1.2020.1)
- tomcat to 9.0.34 (current `Dockerfile` does not build as 9.0.31 is not available anymore at used upstream)
- alpine linux to 3.11 (was: 3.10)
